### PR TITLE
feature/PCESA-2283 (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.4] - 2020-08-12
+### Added
+### changed
+* Removed 'required' fields CHECKSUM and CHECKSUM_TYPE from the file schema
+* Added SHA-2 family checksum type to schema
+* Added SHA-256, SHA-512 checksum types to schema
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 
 ## [1.3] - 2020-04-24
 ### Added

--- a/cumulus_sns_schema.json
+++ b/cumulus_sns_schema.json
@@ -31,6 +31,9 @@
             "description  ": "Type of the checksum (e.g. md5). Optional. If no checksumType is defined for a file, it is assumed to be md5",
             "type": "string",
             "enum": [
+              "SHA-512",
+              "SHA-256",
+              "SHA-2",
               "SHA-1",
               "md5"
             ]
@@ -48,8 +51,6 @@
           "type",
           "uri",
           "size",
-          "checksum",
-          "checksumType",
           "name"
         ]
     },
@@ -83,7 +84,8 @@
         "1.0",
         "1.1",
         "1.2",
-        "1.3"
+        "1.3",
+        "1.4"
       ]
     },
     "receivedTime": {

--- a/samples/cumulus_sns_v1.4_notification.json
+++ b/samples/cumulus_sns_v1.4_notification.json
@@ -1,0 +1,28 @@
+{
+  "version":"1.4",
+  "provider": "PODAAC_SWOT",
+  "collection": "SWOT_Prod_l2:1",
+  "submissionTime":"2017-09-30T03:42:29.791198",
+  "identifier": "1234-abcd-efg0-9876",
+  "product":
+    {
+      "name": "sampleGranuleName001",
+      "dataVersion": "001",
+      "files": [
+        {
+          "type": "data",
+          "uri": "s3://sampleIngestBucket/prod_20170926T11:30:36/production_file.nc",
+          "name":"production_file.nc",
+          "size": 123456
+        },
+        {
+          "type": "browse",
+          "uri": "s3://sampleIngestBucket/prod_20170926T11:30:36/production_file.png",
+          "name":"production_file.png",
+          "checksum":"12312312312313",
+          "checksumType":"SHA-512",
+          "size": 12345
+        }
+      ]
+    }
+}


### PR DESCRIPTION
* v 1.4 makes checksum/checksumtype optional elements, and add the sha-2 family

* added new changelog

* Added sha-256, 512

Co-authored-by: gangl <michael.e.gangl@jpl.nasa.gov>