### PR TITLE
Allow collection to be a JSON object including short name and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The below fields are for sending a CNM submission, most often from a SIPS or SDS
 |version |	yes	| Version of the CNM to use/parse with |	1.0, 1.1, 1.2, 1.3 |
 | submissionTime |	yes |	The time the message was created (and presumably sent) to the DAAC Topic/Stream.	| |
 | identifier |	yes |	Unique identifier for the message as a whole. It is the senders responsibility to ensure uniqueness. This identifier can be used in response messages to provide traceability.	|  |
-| collection |	yes |	The collection to which the granule belongs. |	This may be used if a generic SNS topic for multiple providers. |
+| collection |	yes |	The collection to which the granule belongs. |	This may be used if a generic SNS topic for multiple providers. <br> It can be either a string for the collection short name (e.g. <i> GLDAS_NOAH025_3H </i>), or a JSON object including the collection name and version (e.g. <i> {"name":"GLDAS_NOAH025_3H", "version":"2.0"} </i>). |
 | provider |	no |	The provider/SIPS identifier which created this message.	| |
 | product |	yes |	A product object (typically a granule), defined below. Only a single product can be defined in each message.	|
 | trace |	no	| Information on the message or who is sending it. This is not used in the processing of the product. informational only.	|

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Upon completion, a CNM Response messages can optionally be sent to a previously 
 ## Specification
 There are two types of messages valid in the CNM. The first message is the notification of new data to a DAAC. The second is the optional response message sent from a DAAC to a SIPS.
 
-See https://git.earthdata.nasa.gov/projects/CUMULUS/repos/cumulus-sns-schema/browse/cumulus_sns_schema.json for an up-to-date JSON Schema.
+See https://git.earthdata.nasa.gov/projects/CUMULUS/repos/cumulus-sns-schema/browse/cumulus_sns_schema.json for an up-to-date JSON Schema.
 
 ### Notification Message Fields
 

--- a/cumulus_sns_schema.json
+++ b/cumulus_sns_schema.json
@@ -73,6 +73,24 @@
         "id",
         "files"
       ]
+    },
+    "collection": {
+      "description": "The collection short name and version.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "collection short name."
+        },
+        "version": {
+          "type": "string",
+          "description": "collection version."
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
     }
   },
   "title": "Cloud Notification Message (cnm) 1.2 ",
@@ -115,7 +133,10 @@
     },
     "collection": {
       "description": "The collection to which these granules will belong.",
-      "type": "string"
+      "anyOf": [
+        { "type": "string" },
+        { "$ref": "#/definitions/collection" }
+      ]
     },
     "provider": {
       "description": "the name of the provider (e.g. SIP, SDS, etc. ) producing these files.",


### PR DESCRIPTION
This PR mainly adapts the sns message schema to allow the collection field to be either a string (collection short name) or a JSON object (collection short name + version).

This is needed because at GESDISC we need to create CNM rules for the same collection with different versions. As a matter of fact, the sqs message consumer [does take collection field as a JSON object which includes short name and version](https://github.com/nasa/cumulus/blob/27616bceb12af72c53265ac6daec60f66fe272dc/packages/api/lib/rulesHelpers.js#L82).

This PR also updated the collection description, and fixed a minor issue with broken link in README.md. This link points to [the sns message schema from Bitbucket](https://git.earthdata.nasa.gov/projects/CUMULUS/repos/cumulus-sns-schema/browse/cumulus_sns_schema.json), which may also need to be adapted accordingly.